### PR TITLE
toolchain: Add CI/CD to build and deploy project to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -4,8 +4,8 @@ on: push
 
 jobs:
   build:
-    name: Build and deploy
-    runs-on: ubuntu-18.04
+    name: Build
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
 
@@ -22,13 +22,23 @@ jobs:
         run:
           python -m build --sdist --wheel --outdir dist/ .
 
+  deploy-test:
+    name: Deploy to Test PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to Test PyPI
         if: github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@mastermaster
+        uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_API_TOKEN_TEST }}
           repository_url: https://test.pypi.org/legacy/
 
+  deploy:
+    name: Deploy to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -23,7 +23,8 @@ jobs:
           python -m build --sdist --wheel --outdir dist/ .
 
       - name: Deploy to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        if: github.ref == 'refs/heads/main'
+        uses: pypa/gh-action-pypi-publish@mastermaster
         with:
           password: ${{ secrets.PYPI_API_TOKEN_TEST }}
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,35 @@
+name: Build and deploy
+
+on: push
+
+jobs:
+  build:
+    name: Build and deploy
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install pypa/build
+        run:
+          python -m pip install build --user
+
+      - name: Build binary wheel and source tarball
+        run:
+          python -m build --sdist --wheel --outdir dist/ .
+
+      - name: Deploy to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN_TEST }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Deploy to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Deploy to Test PyPI
         if: github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN_TEST }}
           repository_url: https://test.pypi.org/legacy/
@@ -41,6 +41,6 @@ jobs:
     steps:
       - name: Deploy to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -26,9 +26,9 @@ jobs:
     name: Deploy to Test PyPI
     needs: build
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to Test PyPI
-        if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN_TEST }}
@@ -38,9 +38,9 @@ jobs:
     name: Deploy to PyPI
     needs: build
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
     steps:
       - name: Deploy to PyPI
-        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-rm -rf dist
-python3 setup.py bdist_wheel sdist --formats gztar && twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,5 @@
 from setuptools import setup, find_packages
 
-
-file = open("README.md", "r")
-LONG_DESCRIPTION = file.read()
-file.close()
-
 file = open("requirements.txt", "r")
 DEPENDENCIES = file.readlines()
 file.close()
@@ -15,8 +10,8 @@ setup(
     name="mkdocs-meta-descriptions-plugin",
     version="0.0.1",
     description="Generate a meta description from the first paragraph in each MkDocs page",
-    long_description=LONG_DESCRIPTION,
-    keywords="mkdocs meta description",
+    long_description="📑 Generate a meta description from the first paragraph in each MkDocs page",
+    keywords="mkdocs meta description paragraph",
     url="https://github.com/prcr/mkdocs-meta-descriptions-plugin",
     author="Paulo Ribeiro",
     author_email="paulo@diffraction.pt",
@@ -33,9 +28,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.7"
     ],
     packages=find_packages(),
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,7 @@ setup(
         "mkdocs.plugins": [
             "meta-descriptions = mkdocs_meta_descriptions_plugin.plugin:MetaDescription"
         ]
-    }
+    },
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"]
 )


### PR DESCRIPTION
Uses:

- https://github.com/marketplace/actions/pypi-publish
    - See [Publishing package distribution releases using GitHub Actions CI/CD workflows](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)
- https://github.com/pypa/setuptools_scm#setuppy-usage