### PR TITLE
fix: Disable setuptools_scm local version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
             "meta-descriptions = mkdocs_meta_descriptions_plugin.plugin:MetaDescription"
         ]
     },
-    use_scm_version=True,
+    use_scm_version={
+        "local_scheme": "no-local-version"
+    },
     setup_requires=["setuptools_scm"]
 )


### PR DESCRIPTION
This is necessary because PyPI doesn't support the local scheme:

https://github.com/pypa/setuptools_scm#extending-setuptools_scm