### PR TITLE
fix: Disable running the GitHub Action on release published

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,10 +1,6 @@
 name: Build and deploy
 
-on:
-  push:
-  release:
-    types:
-      - published
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
The workflow is already triggered by the push event.