### PR TITLE
fix: Include pymdown-extensions directly in main requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs>=1.0.4
+pymdown-extensions==8.1.1
 beautifulsoup4==4.9.3
 lxml==4.6.3

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,6 +2,5 @@ pytest==6.2.3
 pytest-cov==2.11.1
 mkdocs==1.1.2
 mkdocs-material==7.1.3
-pymdown-extensions==8.1.1
 click==7.1.2
 -e .


### PR DESCRIPTION
This ensures that people using the plugin will have access to the meta extension.