### PR TITLE
fix: Output page URL paths in exported CSV

### DIFF
--- a/mkdocs_meta_descriptions_plugin/export.py
+++ b/mkdocs_meta_descriptions_plugin/export.py
@@ -30,10 +30,10 @@ class Export:
                 soup = BeautifulSoup(html, features="lxml")
                 meta_tag = soup.select_one('meta[name="description"]')
                 if meta_tag:
-                    meta_descriptions[page.file.dest_path] = meta_tag.get("content")
+                    meta_descriptions[page.url] = meta_tag.get("content")
                 else:
                     count_missing += 1
-                    meta_descriptions[page.file.dest_path] = ""
+                    meta_descriptions[page.url] = ""
         if count_missing > 0:
             logger.warning(
                 PLUGIN_TAG
@@ -48,8 +48,8 @@ class Export:
             with open(output_file_path, "w") as csv_file:
                 csv_writer = csv.writer(csv_file)
                 csv_writer.writerow(["Page", "Meta description"])
-                for page_rel_path, meta_description in self._meta_descriptions.items():
-                    csv_writer.writerow([page_rel_path, meta_description])
+                for url, meta_description in self._meta_descriptions.items():
+                    csv_writer.writerow([url, meta_description])
         else:
             logger.error(
                 PLUGIN_TAG + "Can't find meta descriptions to write to CSV file"

--- a/test/meta_descriptions.csv
+++ b/test/meta_descriptions.csv
@@ -1,11 +1,11 @@
 Page,Meta description
-index.html,For full documentation visit mkdocs.org.
-escape_html_entities/index.html,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
-filename with spaces/index.html,First paragraph.
-first_paragraph/index.html,First paragraph.
-first_paragraph_no_heading/index.html,First paragraph.
-first_paragraph_no_intro/index.html,Value of site_description on mkdocs.yml
-first_paragraph_no_paragraph/index.html,Value of site_description on mkdocs.yml
-front_matter_description/index.html,Value of meta description on front_matter_description.md
-subdirectory/index.html,For full documentation visit mkdocs.org.
-subdirectory/first_paragraph/index.html,First paragraph.
+,For full documentation visit mkdocs.org.
+escape_html_entities/,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
+filename%20with%20spaces/,First paragraph.
+first_paragraph/,First paragraph.
+first_paragraph_no_heading/,First paragraph.
+first_paragraph_no_intro/,Value of site_description on mkdocs.yml
+first_paragraph_no_paragraph/,Value of site_description on mkdocs.yml
+front_matter_description/,Value of meta description on front_matter_description.md
+subdirectory/,For full documentation visit mkdocs.org.
+subdirectory/first_paragraph/,First paragraph.

--- a/test/meta_descriptions_no_directory_urls.csv
+++ b/test/meta_descriptions_no_directory_urls.csv
@@ -1,7 +1,7 @@
 Page,Meta description
 index.html,For full documentation visit mkdocs.org.
 escape_html_entities.html,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
-filename with spaces.html,First paragraph.
+filename%20with%20spaces.html,First paragraph.
 first_paragraph.html,First paragraph.
 first_paragraph_no_heading.html,First paragraph.
 first_paragraph_no_intro.html,Value of site_description on mkdocs.yml

--- a/test/meta_descriptions_no_site_description.csv
+++ b/test/meta_descriptions_no_site_description.csv
@@ -1,11 +1,11 @@
 Page,Meta description
-index.html,For full documentation visit mkdocs.org.
-escape_html_entities/index.html,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
-filename with spaces/index.html,First paragraph.
-first_paragraph/index.html,First paragraph.
-first_paragraph_no_heading/index.html,First paragraph.
-first_paragraph_no_intro/index.html,
-first_paragraph_no_paragraph/index.html,
-front_matter_description/index.html,Value of meta description on front_matter_description.md
-subdirectory/index.html,For full documentation visit mkdocs.org.
-subdirectory/first_paragraph/index.html,First paragraph.
+,For full documentation visit mkdocs.org.
+escape_html_entities/,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
+filename%20with%20spaces/,First paragraph.
+first_paragraph/,First paragraph.
+first_paragraph_no_heading/,First paragraph.
+first_paragraph_no_intro/,
+first_paragraph_no_paragraph/,
+front_matter_description/,Value of meta description on front_matter_description.md
+subdirectory/,For full documentation visit mkdocs.org.
+subdirectory/first_paragraph/,First paragraph.

--- a/test/meta_descriptions_no_site_description_no_directory_urls.csv
+++ b/test/meta_descriptions_no_site_description_no_directory_urls.csv
@@ -1,7 +1,7 @@
 Page,Meta description
 index.html,For full documentation visit mkdocs.org.
 escape_html_entities.html,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
-filename with spaces.html,First paragraph.
+filename%20with%20spaces.html,First paragraph.
 first_paragraph.html,First paragraph.
 first_paragraph_no_heading.html,First paragraph.
 first_paragraph_no_intro.html,


### PR DESCRIPTION
Use URL paths to identify the pages in the generated CSV file.