### PR TITLE
test: Fix mkdocs version so that all tests can run

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 pytest==6.2.4
 pytest-cov==2.12.0
 coverage==5.5
+mkdocs==1.1.2
 mkdocs-material==7.1.7
 -e .


### PR DESCRIPTION
Version 1.2 of mkdocs [introduces some breaking changes](https://www.mkdocs.org/about/release-notes/#version-12-2021-06-04) that prevent a lot of tests from running but that continue to be useful when using mkdocs 1.1.2.