### PR TITLE
fix: Ignore paragraphs in admonition cards

### DIFF
--- a/mkdocs_meta_descriptions_plugin/plugin.py
+++ b/mkdocs_meta_descriptions_plugin/plugin.py
@@ -22,7 +22,7 @@ class MetaDescription(BasePlugin):
         # Strip page subsections to improve performance
         html = re.split(self._headings_pattern, html, maxsplit=1)[0]
         # Select first paragraph directly under body
-        first_paragraph = BeautifulSoup(html, "html.parser").select_one("p")
+        first_paragraph = BeautifulSoup(html, "html.parser").select_one("p:not(div.admonition > p)")
         if first_paragraph is not None:
             # Found the first paragraph, return stripped and escaped text
             return escape(first_paragraph.get_text().strip())

--- a/tests/docs/admonition-before-first-paragraph.md
+++ b/tests/docs/admonition-before-first-paragraph.md
@@ -1,0 +1,17 @@
+# Heading 1
+
+!!! note
+    This paragraph is inside a Note admonition.
+
+First paragraph.
+
+![Image](image.png)
+
+Second paragraph.
+
+- One
+- Two 
+  
+## Heading 2
+
+First paragraph under h2.

--- a/tests/meta-descriptions-no-directory-urls.csv
+++ b/tests/meta-descriptions-no-directory-urls.csv
@@ -1,5 +1,6 @@
 Page,Meta description
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/index.html,For full documentation visit mkdocs.org.
+https://prcr.github.io/mkdocs-meta-descriptions-plugin/admonition-before-first-paragraph.html,First paragraph.
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/escape-html-entities.html,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/filename%20with%20spaces.html,First paragraph.
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/first-paragraph-no-heading.html,First paragraph.

--- a/tests/meta-descriptions-no-site-description-no-directory-urls.csv
+++ b/tests/meta-descriptions-no-site-description-no-directory-urls.csv
@@ -1,5 +1,6 @@
 Page,Meta description
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/index.html,For full documentation visit mkdocs.org.
+https://prcr.github.io/mkdocs-meta-descriptions-plugin/admonition-before-first-paragraph.html,First paragraph.
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/escape-html-entities.html,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/filename%20with%20spaces.html,First paragraph.
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/first-paragraph-no-heading.html,First paragraph.

--- a/tests/meta-descriptions-no-site-description.csv
+++ b/tests/meta-descriptions-no-site-description.csv
@@ -1,5 +1,6 @@
 Page,Meta description
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/,For full documentation visit mkdocs.org.
+https://prcr.github.io/mkdocs-meta-descriptions-plugin/admonition-before-first-paragraph/,First paragraph.
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/escape-html-entities/,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/filename%20with%20spaces/,First paragraph.
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/first-paragraph-no-heading/,First paragraph.

--- a/tests/meta-descriptions-no-site-url-no-directory-urls.csv
+++ b/tests/meta-descriptions-no-site-url-no-directory-urls.csv
@@ -1,5 +1,6 @@
 Page,Meta description
 index.html,For full documentation visit mkdocs.org.
+admonition-before-first-paragraph.html,First paragraph.
 escape-html-entities.html,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
 filename%20with%20spaces.html,First paragraph.
 first-paragraph-no-heading.html,First paragraph.

--- a/tests/meta-descriptions-no-site-url.csv
+++ b/tests/meta-descriptions-no-site-url.csv
@@ -1,5 +1,6 @@
 Page,Meta description
 ,For full documentation visit mkdocs.org.
+admonition-before-first-paragraph/,First paragraph.
 escape-html-entities/,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
 filename%20with%20spaces/,First paragraph.
 first-paragraph-no-heading/,First paragraph.

--- a/tests/meta-descriptions.csv
+++ b/tests/meta-descriptions.csv
@@ -1,5 +1,6 @@
 Page,Meta description
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/,For full documentation visit mkdocs.org.
+https://prcr.github.io/mkdocs-meta-descriptions-plugin/admonition-before-first-paragraph/,First paragraph.
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/escape-html-entities/,"First paragraph with HTML entities: ""quotes"", 'single quotes', <greater and less than>, &ampersand&."
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/filename%20with%20spaces/,First paragraph.
 https://prcr.github.io/mkdocs-meta-descriptions-plugin/first-paragraph-no-heading/,First paragraph.

--- a/tests/mkdocs-export-csv-no-site-description.yml
+++ b/tests/mkdocs-export-csv-no-site-description.yml
@@ -11,3 +11,4 @@ plugins:
 
 markdown_extensions:
     - meta
+    - admonition

--- a/tests/mkdocs-export-csv-no-site-url.yml
+++ b/tests/mkdocs-export-csv-no-site-url.yml
@@ -11,3 +11,4 @@ plugins:
 
 markdown_extensions:
     - meta
+    - admonition

--- a/tests/mkdocs-export-csv.yml
+++ b/tests/mkdocs-export-csv.yml
@@ -12,3 +12,4 @@ plugins:
 
 markdown_extensions:
     - meta
+    - admonition

--- a/tests/mkdocs-no-site-description.yml
+++ b/tests/mkdocs-no-site-description.yml
@@ -9,3 +9,4 @@ plugins:
 
 markdown_extensions:
     - meta
+    - admonition

--- a/tests/mkdocs.yml
+++ b/tests/mkdocs.yml
@@ -11,3 +11,4 @@ plugins:
 
 markdown_extensions:
     - meta
+    - admonition


### PR DESCRIPTION
Ignores paragraphs for meta descriptions if they're from an admonition card.

Fixes #95.