### PR TITLE
feature: Configure verbosity of log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Use the following options to configure the behavior of the plugin:
 ```yaml
 plugins:
   - meta-descriptions:
-      export_csv: false  
+      export_csv: false
+      verbose: false
 ```
 
 ### `export_csv`
@@ -69,6 +70,12 @@ plugins:
 If `true`, the plugin exports the meta descriptions of all Markdown pages to the CSV file `<site_dir>/meta-descriptions.csv`. The default is `false`.
 
 This is useful to review and keep track of all the meta descriptions in your pages, especially if you're maintaining a big site.
+
+### `verbose`
+
+If `true`, the plugin outputs a summary of how many pages have meta descriptions and other information while building your site. The default is `false`.
+
+Alternatively, you can see the same information by running MkDocs with the `--verbose` flag.
 
 ## See also
 

--- a/mkdocs_meta_descriptions_plugin/common.py
+++ b/mkdocs_meta_descriptions_plugin/common.py
@@ -1,17 +1,23 @@
+import logging
 from logging import getLogger
-
-from mkdocs.plugins import BasePlugin
 
 
 class Logger:
+    _initialized = False
+    _tag = "[meta-descriptions] "
+    _logger = getLogger("mkdocs.mkdocs_meta_descriptions_plugin")
+    _verbose = False
+
     Debug, Info, Warning, Error = range(0, 4)
 
-    def __init__(self, verbose):
-        self._tag = "[meta-descriptions] "
-        self._logger = getLogger("mkdocs.mkdocs_meta_descriptions_plugin")
-        self._verbose = verbose
+    def initialize(self, config):
+        self._verbose = config.get("verbose", False)
+        self._initialized = True
 
     def write(self, log_level, message):
+        if not self._initialized:
+            self._logger.warning(self._tag + "'Logger' object not initialized yet, using default configurations")
+
         message = self._tag + message
         if log_level == self.Debug:
             self._logger.debug(message)
@@ -27,4 +33,4 @@ class Logger:
             self._logger.error(message)
 
 
-logger = Logger(BasePlugin.config.get("verbose", False))
+logger = Logger()

--- a/mkdocs_meta_descriptions_plugin/common.py
+++ b/mkdocs_meta_descriptions_plugin/common.py
@@ -1,22 +1,26 @@
 import logging
 
+from mkdocs.plugins import BasePlugin
+
 
 class Logger:
-    _tag = "[meta-descriptions] "
-    _logger = logging.getLogger("mkdocs.mkdocs_meta_descriptions_plugin")
-
     Debug, Info, Warning, Error = range(0, 4)
+
+    def __init__(self, verbose):
+        self._tag = "[meta-descriptions] "
+        self._logger = logging.getLogger("mkdocs.mkdocs_meta_descriptions_plugin")
+        self._verbose = verbose
 
     def write(self, log_level, message):
         message = self._tag + message
         if log_level == self.Debug:
             self._logger.debug(message)
-        if log_level == self.Info:
+        elif log_level == self.Info:
             self._logger.info(message)
-        if log_level == self.Warning:
+        elif log_level == self.Warning:
             self._logger.warning(message)
-        if log_level == self.Error:
+        elif log_level == self.Error:
             self._logger.error(message)
 
 
-logger = Logger()
+logger = Logger(BasePlugin.config.get("verbose", False))

--- a/mkdocs_meta_descriptions_plugin/common.py
+++ b/mkdocs_meta_descriptions_plugin/common.py
@@ -1,4 +1,22 @@
 import logging
 
-logger = logging.getLogger("mkdocs.mkdocs_meta_descriptions_plugin")
-PLUGIN_TAG = "[meta-descriptions] "
+
+class Logger:
+    _tag = "[meta-descriptions] "
+    _logger = logging.getLogger("mkdocs.mkdocs_meta_descriptions_plugin")
+
+    Debug, Info, Warning, Error = range(0, 4)
+
+    def write(self, log_level, message):
+        message = self._tag + message
+        if log_level == self.Debug:
+            self._logger.debug(message)
+        if log_level == self.Info:
+            self._logger.info(message)
+        if log_level == self.Warning:
+            self._logger.warning(message)
+        if log_level == self.Error:
+            self._logger.error(message)
+
+
+logger = Logger()

--- a/mkdocs_meta_descriptions_plugin/common.py
+++ b/mkdocs_meta_descriptions_plugin/common.py
@@ -1,4 +1,4 @@
-import logging
+from logging import getLogger
 
 from mkdocs.plugins import BasePlugin
 
@@ -8,7 +8,7 @@ class Logger:
 
     def __init__(self, verbose):
         self._tag = "[meta-descriptions] "
-        self._logger = logging.getLogger("mkdocs.mkdocs_meta_descriptions_plugin")
+        self._logger = getLogger("mkdocs.mkdocs_meta_descriptions_plugin")
         self._verbose = verbose
 
     def write(self, log_level, message):

--- a/mkdocs_meta_descriptions_plugin/common.py
+++ b/mkdocs_meta_descriptions_plugin/common.py
@@ -16,7 +16,11 @@ class Logger:
         if log_level == self.Debug:
             self._logger.debug(message)
         elif log_level == self.Info:
-            self._logger.info(message)
+            # Print info messages only if the verbose option is True
+            if self._verbose:
+                self._logger.info(message)
+            else:
+                self._logger.debug(message)
         elif log_level == self.Warning:
             self._logger.warning(message)
         elif log_level == self.Error:

--- a/mkdocs_meta_descriptions_plugin/export.py
+++ b/mkdocs_meta_descriptions_plugin/export.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 
-from .common import PLUGIN_TAG, logger
+from .common import logger
 
 
 class Export:
@@ -34,16 +34,13 @@ class Export:
                     count_missing += 1
                     meta_descriptions[page.url] = ""
         if count_missing > 0:
-            logger.warning(
-                PLUGIN_TAG
-                + f"Couldn't find meta descriptions for {count_missing} HTML pages"
-            )
+            logger.write(logger.Warning, f"Couldn't find meta descriptions for {count_missing} HTML pages")
         return meta_descriptions
 
     def write_csv(self, output_file="meta-descriptions.csv"):
         output_file_path = os.path.join(self._site_dir, output_file)
         if self._meta_descriptions:
-            logger.info(PLUGIN_TAG + f"Writing {output_file_path}")
+            logger.write(logger.Info, f"Writing {output_file_path}")
             with open(output_file_path, "w") as csv_file:
                 csv_writer = csv.writer(csv_file)
                 csv_writer.writerow(["Page", "Meta description"])
@@ -52,6 +49,4 @@ class Export:
                         [urljoin(self._site_url, url_path), meta_description]
                     )
         else:
-            logger.error(
-                PLUGIN_TAG + "Can't find meta descriptions to write to CSV file"
-            )
+            logger.write(logger.Error, "Can't find meta descriptions to write to CSV file")

--- a/mkdocs_meta_descriptions_plugin/export.py
+++ b/mkdocs_meta_descriptions_plugin/export.py
@@ -49,4 +49,4 @@ class Export:
                         [urljoin(self._site_url, url_path), meta_description]
                     )
         else:
-            logger.write(logger.Error, "Can't find meta descriptions to write to CSV file")
+            logger.write(logger.Warning, "Can't find meta descriptions to write to CSV file")

--- a/mkdocs_meta_descriptions_plugin/plugin.py
+++ b/mkdocs_meta_descriptions_plugin/plugin.py
@@ -35,6 +35,10 @@ class MetaDescription(BasePlugin):
             # Didn't find the first paragraph
             return ""
 
+    def on_config(self, config):
+        logger.initialize(self.config)
+        return config
+
     def on_page_content(self, html, page, config, files):
         if page.meta.get("description", None):
             # Skip pages that already have an explicit meta description

--- a/mkdocs_meta_descriptions_plugin/plugin.py
+++ b/mkdocs_meta_descriptions_plugin/plugin.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
 
-from .common import PLUGIN_TAG, logger
+from .common import logger
 from .export import Export
 
 
@@ -59,7 +59,7 @@ class MetaDescription(BasePlugin):
             f"{self._count_meta + self._count_first_paragraph} out of " \
             f"{self._count_meta + self._count_first_paragraph + self._count_empty} pages have meta descriptions " \
             f"({self._count_first_paragraph} use the first paragraph)"
-        logger.info(PLUGIN_TAG + summary)
+        logger.write(logger.Info, summary)
         if self.config.get("export_csv", False):
             # Export meta descriptions to CSV file
             Export(self._pages, config).write_csv()

--- a/mkdocs_meta_descriptions_plugin/plugin.py
+++ b/mkdocs_meta_descriptions_plugin/plugin.py
@@ -13,6 +13,7 @@ class MetaDescription(BasePlugin):
 
     config_scheme = (
         ("export_csv", config_options.Type(bool, default=False)),
+        ("verbose", config_options.Type(bool, default=False)),
     )
 
     def __init__(self):

--- a/tests/mkdocs-verbose.yml
+++ b/tests/mkdocs-verbose.yml
@@ -1,0 +1,15 @@
+site_name: Test mkdocs-meta-descriptions-plugin
+site_description: "Value of site_description on mkdocs.yml"
+
+theme:
+    name: material
+
+plugins:
+    - search
+    - meta-descriptions:
+        export_csv: true
+        verbose: true
+
+markdown_extensions:
+    - meta
+    - admonition

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -67,12 +67,6 @@ class TestPlugin:
         for f in files:
             assert os.path.isfile(f.abs_dest_path)
 
-    def test_build_summary(self, build):
-        result, files, _, _ = build
-        expected = f"INFO     -  [meta-descriptions] 9 out of {len(files)} pages have meta descriptions " \
-                   f"(8 use the first paragraph)"
-        assert expected in result.output
-
     def test_index_md(self, build):
         _, files, _, _ = build
         expected = "For full documentation visit mkdocs.org."
@@ -119,6 +113,13 @@ class TestPlugin:
             "<greater and less than>, &ampersand&."
         )
         assert get_meta_description(files, "escape-html-entities.md") == expected
+
+    def test_build_summary(self, build):
+        result, files, mkdocs_yml, _ = build
+        if "verbose" in mkdocs_yml:
+            expected = f"INFO     -  [meta-descriptions] 9 out of {len(files)} pages have meta descriptions " \
+                       f"(8 use the first paragraph)"
+            assert expected in result.output
 
 
 class TestExport:


### PR DESCRIPTION
Add new option `verbose` to allow configuring if the plugin should output log messages with the `DEBUG` or `INFO` level.