### PR TITLE
feature: Output summary of pages with meta descriptions

### DIFF
--- a/mkdocs_meta_descriptions_plugin/export.py
+++ b/mkdocs_meta_descriptions_plugin/export.py
@@ -18,9 +18,6 @@ class Export:
         self._meta_descriptions = self._read_meta_descriptions(pages)
 
     def _read_meta_descriptions(self, pages):
-        logger.info(
-            PLUGIN_TAG + f"Reading meta descriptions from {len(pages)} HTML pages"
-        )
         count_missing = 0
         meta_descriptions = {}
         # Get meta descriptions only for Markdown documentation pages

--- a/mkdocs_meta_descriptions_plugin/plugin.py
+++ b/mkdocs_meta_descriptions_plugin/plugin.py
@@ -18,9 +18,9 @@ class MetaDescription(BasePlugin):
     def __init__(self):
         self._headings_pattern = re.compile("<h[2-6]", flags=re.IGNORECASE)
         self._pages = []
-        self._count_meta = 0  # Pages with meta descriptions defined on the page meta-data
+        self._count_meta = 0             # Pages with meta descriptions defined on the page meta-data
         self._count_first_paragraph = 0  # Pages with meta descriptions from the first paragraph
-        self._count_empty = 0  # Pages without meta descriptions
+        self._count_empty = 0            # Pages without meta descriptions
 
     def _get_first_paragraph_text(self, html):
         # Strip page subsections to improve performance

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -116,12 +116,6 @@ class TestPlugin:
 
 
 class TestExport:
-    def test_export_csv_build(self, build):
-        result, files, mkdocs_yml, _ = build
-        if "export-csv" in mkdocs_yml:
-            expected = f"INFO     -  [meta-descriptions] Reading meta descriptions from {len(files)} HTML pages"
-            assert expected in result.output
-
     def test_export_csv_output(self, build):
         _, files, mkdocs_yml, use_directory_urls = build
         if mkdocs_yml.endswith("mkdocs-export-csv.yml"):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -68,8 +68,8 @@ class TestPlugin:
             assert os.path.isfile(f.abs_dest_path)
 
     def test_build_summary(self, build):
-        result, files, mkdocs_yml, _ = build
-        expected = f"INFO     -  [meta-descriptions] 9 out of 11 pages have meta descriptions " \
+        result, files, _, _ = build
+        expected = f"INFO     -  [meta-descriptions] 9 out of {len(files)} pages have meta descriptions " \
                    f"(8 use the first paragraph)"
         assert expected in result.output
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -67,6 +67,12 @@ class TestPlugin:
         for f in files:
             assert os.path.isfile(f.abs_dest_path)
 
+    def test_build_summary(self, build):
+        result, files, mkdocs_yml, _ = build
+        expected = f"INFO     -  [meta-descriptions] 9 out of 11 pages have meta descriptions " \
+                   f"(8 use the first paragraph)"
+        assert expected in result.output
+
     def test_index_md(self, build):
         _, files, _, _ = build
         expected = "For full documentation visit mkdocs.org."


### PR DESCRIPTION
Outputs a line including how many pages have (or don't have) meta descriptions. For example:

```
$ mkdocs build
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: /home/prcr/tmp/site
INFO     -  [meta-descriptions] 10 out of 10 pages have meta descriptions (9 use the first paragraph)
INFO     -  [meta-descriptions] Writing /home/prcr/tmp/site/meta-descriptions.csv
INFO     -  Documentation built in 0.27 seconds
```