### PR TITLE
feature: Add Python 3.10 as a supported version

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9"
+        "Programming Language :: Python :: 3.10"
     ],
     packages=["mkdocs_meta_descriptions_plugin"],
     entry_points={


### PR DESCRIPTION
Tests the plugin using Python 3.10 and updates the list of supported Python versions on PyPI.org.