### PR TITLE
clean: Change verbose option to quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Use the following options to configure the behavior of the plugin:
 plugins:
   - meta-descriptions:
       export_csv: false
-      verbose: false
+      quiet: false
 ```
 
 ### `export_csv`
@@ -71,11 +71,11 @@ If `true`, the plugin exports the meta descriptions of all Markdown pages to the
 
 This is useful to review and keep track of all the meta descriptions in your pages, especially if you're maintaining a big site.
 
-### `verbose`
+### `quiet`
 
-If `true`, the plugin outputs a summary of how many pages have meta descriptions and other information while building your site. The default is `false`.
+If `true`, the plugin logs messages of level `INFO` using the level `DEBUG` instead. The default is `false`.
 
-Alternatively, you can see the same information by running MkDocs with the `--verbose` flag.
+Use this option to have a cleaner MkDocs console output. You can still see all logs by running MkDocs with the `--verbose` flag.
 
 ## See also
 

--- a/mkdocs_meta_descriptions_plugin/common.py
+++ b/mkdocs_meta_descriptions_plugin/common.py
@@ -5,12 +5,12 @@ class Logger:
     _initialized = False
     _tag = "[meta-descriptions] "
     _logger = getLogger("mkdocs.mkdocs_meta_descriptions_plugin")
-    _verbose = False
+    _quiet = False
 
     Debug, Info, Warning, Error = range(0, 4)
 
     def initialize(self, config):
-        self._verbose = config.get("verbose", False)
+        self._quiet = config.get("quiet", False)
         self._initialized = True
 
     def write(self, log_level, message):
@@ -21,11 +21,11 @@ class Logger:
         if log_level == self.Debug:
             self._logger.debug(message)
         elif log_level == self.Info:
-            # Print info messages only if the verbose option is True
-            if self._verbose:
-                self._logger.info(message)
-            else:
+            # If quiet is True, print INFO messages as DEBUG
+            if self._quiet:
                 self._logger.debug(message)
+            else:
+                self._logger.info(message)
         elif log_level == self.Warning:
             self._logger.warning(message)
         elif log_level == self.Error:

--- a/mkdocs_meta_descriptions_plugin/plugin.py
+++ b/mkdocs_meta_descriptions_plugin/plugin.py
@@ -13,7 +13,7 @@ class MetaDescription(BasePlugin):
 
     config_scheme = (
         ("export_csv", config_options.Type(bool, default=False)),
-        ("verbose", config_options.Type(bool, default=False)),
+        ("quiet", config_options.Type(bool, default=False)),
     )
 
     def __init__(self):

--- a/tests/mkdocs-quiet.yml
+++ b/tests/mkdocs-quiet.yml
@@ -8,7 +8,7 @@ plugins:
     - search
     - meta-descriptions:
         export_csv: true
-        verbose: true
+        quiet: true
 
 markdown_extensions:
     - meta

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -115,7 +115,7 @@ class TestPlugin:
         assert get_meta_description(files, "escape-html-entities.md") == expected
 
     def test_build_summary(self, build):
-        result, files, mkdocs_yml, _ = build
+        result, _, mkdocs_yml, _ = build
         if "quiet" in mkdocs_yml:
             not_expected = f"INFO     -  [meta-descriptions]"
             assert not_expected not in result.output

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -116,10 +116,9 @@ class TestPlugin:
 
     def test_build_summary(self, build):
         result, files, mkdocs_yml, _ = build
-        if "verbose" in mkdocs_yml:
-            expected = f"INFO     -  [meta-descriptions] 9 out of {len(files)} pages have meta descriptions " \
-                       f"(8 use the first paragraph)"
-            assert expected in result.output
+        if "quiet" in mkdocs_yml:
+            not_expected = f"INFO     -  [meta-descriptions]"
+            assert not_expected not in result.output
 
 
 class TestExport:


### PR DESCRIPTION
Changes the option `verbose` to `quiet`. This change provides better semantics to allow logging minimal `INFO` messages by default.