### PR TITLE
doc: Add support for Python 3.10 in v2.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
+-   Added support for Python 3.10.
 -   Option `quiet` to stop info messages from being displayed on the console when running MkDocs.
 -   New debug messages to log which meta description the plugin used on each page, available by running MkDocs with the `--verbose` flag.
 


### PR DESCRIPTION
I forgot to include this update in the changelog.