### PR TITLE
clean: Remove unneeded meta Markdown extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,6 @@ To set up and use the plugin:
 
     > **Note:** If you have no `plugins` entry in your `mkdocs.yml` file yet, you'll likely also want to add the `search` plugin. MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
 
-3.  Activate the [Meta-Data extension](https://python-markdown.github.io/extensions/meta_data/) in your `mkdocs.yml`:
-
-    ```yaml
-    markdown_extensions:
-      - meta
-    ```
-
 ## Configuring the plugin
 
 Use the following options to configure the behavior of the plugin:

--- a/tests/mkdocs-export-csv-no-site-description.yml
+++ b/tests/mkdocs-export-csv-no-site-description.yml
@@ -10,5 +10,4 @@ plugins:
         export_csv: true
 
 markdown_extensions:
-    - meta
     - admonition

--- a/tests/mkdocs-export-csv-no-site-url.yml
+++ b/tests/mkdocs-export-csv-no-site-url.yml
@@ -10,5 +10,4 @@ plugins:
         export_csv: true
 
 markdown_extensions:
-    - meta
     - admonition

--- a/tests/mkdocs-export-csv.yml
+++ b/tests/mkdocs-export-csv.yml
@@ -11,5 +11,4 @@ plugins:
         export_csv: true
 
 markdown_extensions:
-    - meta
     - admonition

--- a/tests/mkdocs-no-site-description.yml
+++ b/tests/mkdocs-no-site-description.yml
@@ -8,5 +8,4 @@ plugins:
     - meta-descriptions
 
 markdown_extensions:
-    - meta
     - admonition

--- a/tests/mkdocs-quiet.yml
+++ b/tests/mkdocs-quiet.yml
@@ -11,5 +11,4 @@ plugins:
         quiet: true
 
 markdown_extensions:
-    - meta
     - admonition

--- a/tests/mkdocs.yml
+++ b/tests/mkdocs.yml
@@ -10,5 +10,4 @@ plugins:
         export_csv: true
 
 markdown_extensions:
-    - meta
     - admonition


### PR DESCRIPTION
The meta Markdown [Meta-Data extension](https://python-markdown.github.io/extensions/meta_data/) is actually not needed since it's already included in MkDocs. For more details, see https://github.com/squidfunk/mkdocs-material/issues/4179.