### PR TITLE
toolchain: Update parameter name repository-url

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -138,7 +138,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.7.1
         with:
           password: ${{ secrets.PYPI_API_TOKEN_TEST }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 
   deploy:
     name: Deploy to PyPI


### PR DESCRIPTION
Updates the GitHub Action pypa/gh-action-pypi-publish according to [these changes](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.7.0).