### PR TITLE
toolchain: Run CI/CD on pull_request_target event

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -1,6 +1,6 @@
 name: CI/CD
 
-on: push
+on: pull_request_target
 
 jobs:
   test:


### PR DESCRIPTION
This should make it possible to run the CI/CD for pull requests opened from forked repositories.