### PR TITLE
test: Fix tests for MkDocs 1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,8 +109,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# mkdocs documentation
+# MkDocs documentation
 /site
+/tests/site
 
 # mypy
 .mypy_cache/

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -167,20 +167,20 @@ class TestChecker:
     def test_checker_long(self, build):
         result, _, mkdocs_yml, _ = build
         if "enable-checks" in mkdocs_yml:
-            expected = "WARNING  -  \x1b[0m[meta-descriptions] Meta description 10 characters longer than 35: " \
+            expected = "WARNING -  \x1b[0m[meta-descriptions] Meta description 10 characters longer than 35: " \
                        "warning-long.md"
             assert expected in result.stderr
 
     def test_checker_short(self, build):
         result, _, mkdocs_yml, _ = build
         if "enable-checks" in mkdocs_yml:
-            expected = "WARNING  -  \x1b[0m[meta-descriptions] Meta description 2 characters shorter than 25: " \
+            expected = "WARNING -  \x1b[0m[meta-descriptions] Meta description 2 characters shorter than 25: " \
                        "warning-short.md"
             assert expected in result.stderr
 
     def test_checker_not_found(self, build):
         result, _, mkdocs_yml, _ = build
         if "enable-checks" in mkdocs_yml:
-            expected = "WARNING  -  \x1b[0m[meta-descriptions] Meta description not found: " \
+            expected = "WARNING -  \x1b[0m[meta-descriptions] Meta description not found: " \
                        "warning-not-found.md"
             assert expected in result.stderr


### PR DESCRIPTION
MkDocs 1.5.0 introduced a minor change to the console output (the lines are indented by one less space, see https://github.com/mkdocs/mkdocs/pull/3282). This pull request updates the tests to take the change into account.