### PR TITLE
clean: Adjust plugin name used in log messages

### DIFF
--- a/mkdocs_meta_descriptions_plugin/common.py
+++ b/mkdocs_meta_descriptions_plugin/common.py
@@ -17,7 +17,7 @@ class Logger:
         _logger = getLogger("mkdocs.plugins." + __name__)
     else:
         _tag = ""
-        _logger = get_plugin_logger(__name__)
+        _logger = get_plugin_logger("meta-descriptions")
     _quiet = False
 
     Debug, Info, Warning, Error = range(0, 4)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -176,7 +176,7 @@ class TestChecker:
                 expected = "WARNING  -  \x1b[0m[meta-descriptions] " \
                            "Meta description 10 characters longer than 35: warning-long.md"
             else:
-                expected = "WARNING -  \x1b[0mmkdocs_meta_descriptions_plugin: " \
+                expected = "WARNING -  \x1b[0mmeta-descriptions: " \
                            "Meta description 10 characters longer than 35: warning-long.md"
             assert expected in result.stderr
 
@@ -187,7 +187,7 @@ class TestChecker:
                 expected = "WARNING  -  \x1b[0m[meta-descriptions] " \
                            "Meta description 2 characters shorter than 25: warning-short.md"
             else:
-                expected = "WARNING -  \x1b[0mmkdocs_meta_descriptions_plugin: " \
+                expected = "WARNING -  \x1b[0mmeta-descriptions: " \
                            "Meta description 2 characters shorter than 25: warning-short.md"
             assert expected in result.stderr
 
@@ -198,6 +198,6 @@ class TestChecker:
                 expected = "WARNING  -  \x1b[0m[meta-descriptions] " \
                            "Meta description not found: warning-not-found.md"
             else:
-                expected = "WARNING -  \x1b[0mmkdocs_meta_descriptions_plugin: " \
+                expected = "WARNING -  \x1b[0mmeta-descriptions: " \
                            "Meta description not found: warning-not-found.md"
             assert expected in result.stderr


### PR DESCRIPTION
Adjusts the changes from https://github.com/prcr/mkdocs-meta-descriptions-plugin/pull/267 to use a more readable plugin name in log messages.