### PR TITLE
clean: Simplify log message containing CSV file output path

### DIFF
--- a/mkdocs_meta_descriptions_plugin/export.py
+++ b/mkdocs_meta_descriptions_plugin/export.py
@@ -47,6 +47,6 @@ class Export:
                     csv_writer.writerow(
                         [urljoin(self._site_url, url_path), meta_description]
                     )
-            logger.write(logger.Info, f"Exported meta descriptions to: {output_file_path}")
+            logger.write(logger.Info, f"Exported meta descriptions to {output_file_path}")
         else:
             logger.write(logger.Warning, "Can't find meta descriptions to write to CSV file")


### PR DESCRIPTION
Since I'm already making changes to the log messages (see https://github.com/prcr/mkdocs-meta-descriptions-plugin/pull/267 and https://github.com/prcr/mkdocs-meta-descriptions-plugin/pull/269), I'm using the opportunity to make this tiny simplification.