### PR TITLE
doc: Add trim option to example plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ plugins:
       enable_checks: false
       min_length: 50
       max_length: 160
+      trim: false
 ```
 
 ### `export_csv`


### PR DESCRIPTION
I forgot to update the example in https://github.com/prcr/mkdocs-meta-descriptions-plugin/pull/268.