### PR TITLE
Revert "toolchain: Run CI/CD on pull_request event (#264)"

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -1,10 +1,6 @@
 name: CI/CD
 
-on:
-  pull_request:
-    branches: main
-  push:
-    branches: main
+on: push
 
 jobs:
   test:


### PR DESCRIPTION
Reverts the changes from #264, as they prevented running the CI/CD when pushing new release tags, and also add unneeded complexity to the GitHub Actions configuration.