### PR TITLE
toolchain: Publish to PyPI with a Trusted Publisher

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -124,6 +124,9 @@ jobs:
     name: Deploy to Test PyPI
     needs: build
     runs-on: ubuntu-latest
+    environment: test
+    permissions:
+      id-token: write
     if: startsWith(github.ref, 'refs/tags') || github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
@@ -137,13 +140,15 @@ jobs:
       - name: Deploy to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.8
         with:
-          password: ${{ secrets.PYPI_API_TOKEN_TEST }}
           repository-url: https://test.pypi.org/legacy/
 
   deploy:
     name: Deploy to PyPI
     needs: build
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v3
@@ -156,8 +161,6 @@ jobs:
 
       - name: Deploy to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.8
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   deploy-gh-pages:
     name: Deploy GitHub Pages


### PR DESCRIPTION
See https://docs.pypi.org/trusted-publishers/using-a-publisher/ for details.