### PR TITLE
clean: Use double-leading underscores to clean up class interfaces

### DIFF
--- a/mkdocs_meta_descriptions_plugin/checker.py
+++ b/mkdocs_meta_descriptions_plugin/checker.py
@@ -5,46 +5,46 @@ from .common import logger
 
 class Checker:
     """Checks meta descriptions against general SEO recommendations."""
-    _initialized = False
-    _check = False
-    _min_length = 50
-    _max_length = 160
-    _template_warning_missing = Template(
+    __initialized = False
+    __check = False
+    __min_length = 50
+    __max_length = 160
+    __template_warning_missing = Template(
         "Meta description not found: $page")
-    _template_warning_length = Template(
+    __template_warning_length = Template(
         "Meta description $character_count character$plural $comparative than $limit: $page")
 
-    def _check_length(self, page):
+    def __check_length(self, page):
         length = len(page.meta.get("description", ""))
         if length == 0:
-            logger.write(logger.Warning, self._template_warning_missing.substitute(page=page.file.src_path))
+            logger.write(logger.Warning, self.__template_warning_missing.substitute(page=page.file.src_path))
             return  # Skip length check
-        elif length < self._min_length:
-            diff = self._min_length - length
-            logger.write(logger.Warning, self._template_warning_length.substitute(character_count=diff,
-                                                                                  plural="s"[:diff != 1],
-                                                                                  comparative="shorter",
-                                                                                  limit=self._min_length,
-                                                                                  page=page.file.src_path))
-        elif length > self._max_length:
-            diff = length - self._max_length
-            logger.write(logger.Warning, self._template_warning_length.substitute(character_count=diff,
-                                                                                  plural="s"[:diff != 1],
-                                                                                  comparative="longer",
-                                                                                  limit=self._max_length,
-                                                                                  page=page.file.src_path))
+        elif length < self.__min_length:
+            diff = self.__min_length - length
+            logger.write(logger.Warning, self.__template_warning_length.substitute(character_count=diff,
+                                                                                   plural="s"[:diff != 1],
+                                                                                   comparative="shorter",
+                                                                                   limit=self.__min_length,
+                                                                                   page=page.file.src_path))
+        elif length > self.__max_length:
+            diff = length - self.__max_length
+            logger.write(logger.Warning, self.__template_warning_length.substitute(character_count=diff,
+                                                                                   plural="s"[:diff != 1],
+                                                                                   comparative="longer",
+                                                                                   limit=self.__max_length,
+                                                                                   page=page.file.src_path))
 
     def initialize(self, config):
-        self._check = config.get("enable_checks")
-        self._min_length = config.get("min_length")
-        self._max_length = config.get("max_length")
-        self._initialized = True
+        self.__check = config.get("enable_checks")
+        self.__min_length = config.get("min_length")
+        self.__max_length = config.get("max_length")
+        self.__initialized = True
 
     def check(self, page):
-        if not self._initialized:
+        if not self.__initialized:
             logger.write(logger.Warning, "'LengthChecker' object not initialized yet, using default configurations")
-        if self._check:
-            self._check_length(page)
+        if self.__check:
+            self.__check_length(page)
 
 
 checker = Checker()

--- a/mkdocs_meta_descriptions_plugin/common.py
+++ b/mkdocs_meta_descriptions_plugin/common.py
@@ -11,38 +11,38 @@ else:
 
 
 class Logger:
-    _initialized = False
+    __initialized = False
     if MKDOCS_VERSION < MKDOCS_1_5_0:
-        _tag = "[meta-descriptions] "
-        _logger = getLogger("mkdocs.plugins." + __name__)
+        __tag = "[meta-descriptions] "
+        __logger = getLogger("mkdocs.plugins." + __name__)
     else:
-        _tag = ""
-        _logger = get_plugin_logger("meta-descriptions")
-    _quiet = False
+        __tag = ""
+        __logger = get_plugin_logger("meta-descriptions")
+    __quiet = False
 
     Debug, Info, Warning, Error = range(0, 4)
 
     def initialize(self, config):
-        self._quiet = config.get("quiet")
-        self._initialized = True
+        self.__quiet = config.get("quiet")
+        self.__initialized = True
 
     def write(self, log_level, message):
-        if not self._initialized:
-            self._logger.warning(self._tag + "'Logger' object not initialized yet, using default configurations")
+        if not self.__initialized:
+            self.__logger.warning(self.__tag + "'Logger' object not initialized yet, using default configurations")
 
-        message = self._tag + message
+        message = self.__tag + message
         if log_level == self.Debug:
-            self._logger.debug(message)
+            self.__logger.debug(message)
         elif log_level == self.Info:
             # If quiet is True, print INFO messages as DEBUG
-            if self._quiet:
-                self._logger.debug(message)
+            if self.__quiet:
+                self.__logger.debug(message)
             else:
-                self._logger.info(message)
+                self.__logger.info(message)
         elif log_level == self.Warning:
-            self._logger.warning(message)
+            self.__logger.warning(message)
         elif log_level == self.Error:
-            self._logger.error(message)
+            self.__logger.error(message)
 
 
 logger = Logger()

--- a/mkdocs_meta_descriptions_plugin/export.py
+++ b/mkdocs_meta_descriptions_plugin/export.py
@@ -12,12 +12,12 @@ class Export:
     """Read meta descriptions from the generated HTML and export them in a CSV file."""
 
     def __init__(self, pages, config):
-        self._body_pattern = re.compile("<body", flags=re.IGNORECASE)
-        self._site_dir = config.get("site_dir")
-        self._site_url = config.get("site_url")
-        self._meta_descriptions = self._read_meta_descriptions(pages)
+        self.__body_pattern = re.compile("<body", flags=re.IGNORECASE)
+        self.__site_dir = config.get("site_dir")
+        self.__site_url = config.get("site_url")
+        self.__meta_descriptions = self.__read_meta_descriptions(pages)
 
-    def _read_meta_descriptions(self, pages):
+    def __read_meta_descriptions(self, pages):
         count_missing = 0
         meta_descriptions = {}
         # Get meta descriptions only for Markdown documentation pages
@@ -25,7 +25,7 @@ class Export:
             with open(page.file.abs_dest_path) as page_file:
                 html = page_file.read()
                 # Strip page body to improve performance
-                html = re.split(self._body_pattern, html, maxsplit=1)[0]
+                html = re.split(self.__body_pattern, html, maxsplit=1)[0]
                 soup = BeautifulSoup(html, "html.parser")
                 meta_tag = soup.select_one('meta[name="description"]')
                 if meta_tag:
@@ -38,14 +38,14 @@ class Export:
         return meta_descriptions
 
     def write_csv(self, output_file="meta-descriptions.csv"):
-        output_file_path = os.path.join(self._site_dir, output_file)
-        if self._meta_descriptions:
+        output_file_path = os.path.join(self.__site_dir, output_file)
+        if self.__meta_descriptions:
             with open(output_file_path, "w") as csv_file:
                 csv_writer = csv.writer(csv_file)
                 csv_writer.writerow(["Page", "Meta description"])
-                for url_path, meta_description in self._meta_descriptions.items():
+                for url_path, meta_description in self.__meta_descriptions.items():
                     csv_writer.writerow(
-                        [urljoin(self._site_url, url_path), meta_description]
+                        [urljoin(self.__site_url, url_path), meta_description]
                     )
             logger.write(logger.Info, f"Exported meta descriptions to {output_file_path}")
         else:


### PR DESCRIPTION
Before, "private" attributes and methods were using the single-leading underscore naming convention which [only signify a weak internal use](https://peps.python.org/pep-0008/#descriptive-naming-styles).