### PR TITLE
toolchain: Pin click version

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 pytest==8.3.5
 pytest-cov==6.1.1
 coverage==7.8.0
+click==8.1.8
 mkdocs-material==9.6.12
 -e .


### PR DESCRIPTION
I'm pinning the version to 8.1 since version 8.2:

* No longer supports Python 3.9
* Removes the `mix_stderror` parameter, see https://github.com/pallets/click/pull/2523 for context.